### PR TITLE
fix: change paymaster transaction to 0 amount

### DIFF
--- a/src/paymaster_flow.rs
+++ b/src/paymaster_flow.rs
@@ -78,7 +78,7 @@ impl PaymasterFlow {
         Eip712TransactionRequest::new()
             .from(address)
             .to(address)
-            .value::<U256>(1u64.into())
+            .value::<U256>(0u64.into())
             .custom_data(Eip712Meta::new().paymaster_params(PaymasterParams {
                 paymaster: self.paymaster,
                 paymaster_input: self.paymaster_encoded_input.clone(),


### PR DESCRIPTION
* Sophon legally can't have any tokens issued to any external addresses; 
* To overcome that changed paymaster flow to send transactions with 0 value;
* Verified on the Sophon's staging: https://explorer.testnet.sophon.xyz/tx/0x7f7fe15cda6fe3b66e3e140bd39f6f9717f4a1fe139ee6eb7af7f01a30ec4939.