### PR TITLE
fix: do not wait for confirmation

### DIFF
--- a/src/deposit.ts
+++ b/src/deposit.ts
@@ -136,7 +136,7 @@ export class DepositFlow extends DepositBaseFlow {
         stepName: STEPS.l2_execution,
         stepTimeoutMs: PRIORITY_OP_TIMEOUT,
         fn: async ({ recordStepGasPrice, recordStepGas, recordStepGasCost }) => {
-          const receipt = await depositHandle.wait(1);
+          const receipt = await depositHandle.wait();
           recordStepGasPrice(unwrap(receipt.gasPrice));
           recordStepGas(unwrap(receipt.gasUsed));
           recordStepGasCost(unwrap(receipt.gasUsed) * unwrap(receipt.gasPrice));

--- a/src/depositUsers.ts
+++ b/src/depositUsers.ts
@@ -106,7 +106,7 @@ export class DepositUserFlow extends DepositBaseFlow {
         await this.wallet._providerL2().getMainContractAddress()
       );
       this.logger.info(`Deposit transaction mined on L1, expecting L2 hash: ${l2TxHash}`);
-      await depositHandle.wait(1);
+      await depositHandle.wait();
       this.logger.info("Deposit transaction mined on L2. Checking status...");
       const watchdogTxResult = await this.getLastExecution(this.wallet.address);
       if (watchdogTxResult.status == null) {

--- a/src/transfer.ts
+++ b/src/transfer.ts
@@ -80,7 +80,7 @@ export class SimpleTxFlow extends BaseFlow {
         stepName: "execution",
         stepTimeoutMs: L2_EXECUTION_TIMEOUT,
         fn: async ({ recordStepGas, recordStepGasPrice, recordStepGasCost }) => {
-          const receipt = await txResponse.wait(1);
+          const receipt = await txResponse.wait();
           recordStepGas(unwrap(receipt.gasUsed));
           recordStepGasPrice(unwrap(receipt.gasPrice));
           recordStepGasCost(BigInt(unwrap(receipt.gasUsed)) * BigInt(unwrap(receipt.gasPrice)));


### PR DESCRIPTION
For some chains there is no load at all other than watchdog. It doesn't make sense to wait for 1 confirmation because there might be no transactions so no new blocks are created