### PR TITLE
fix: set metric_status for failures

### DIFF
--- a/src/flowMetric.ts
+++ b/src/flowMetric.ts
@@ -191,6 +191,7 @@ export class FlowMetricRecorder {
         break;
       }
       case Status.FAIL: {
+        store.metric_status.set({ flow: this.flowName }, 0);
         store.metric_status_hist.observe({ flow: this.flowName }, 0);
         break;
       }


### PR DESCRIPTION
returns line that was removed in the last PR back