### PR TITLE
fix: use correct units for settlement SLI. Increase default settlement deadline to 1.5 hours

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,11 +147,11 @@ Options:
 This flow is used to ensure timely L1 settlement.
 Every second it evaluates the age of the oldest unsettled (also known as unexecuted on L1) L2 block.
 This age is measured against the newest L1 block (that is, not local clock time or newest L2 block).
-If it's older than `SETTLEMENT_DEADLINE_SEC` (15 minutes by default), the flow is considered failed.
+If it's older than `SETTLEMENT_DEADLINE` (15 minutes by default), the flow is considered failed.
 
 Options:
 - `FLOW_SETTLEMENT_ENABLE` -- set to `1` to enable 
-- `SETTLEMENT_DEADLINE_SEC` -- acceptable settlement delay
+- `SETTLEMENT_DEADLINE` -- acceptable settlement delay in ms (defaults to 1.5 hours)
 - `FLOW_SETTLEMENT_INTERVAL` -- interval in ms (defaults to 1000 ms = 1 second)
 
 ---

--- a/src/configs.ts
+++ b/src/configs.ts
@@ -1,4 +1,4 @@
 import { MIN, SEC } from "./utils";
 
 export const L2_EXECUTION_TIMEOUT = +(process.env.L2_EXECUTION_TIMEOUT ?? 15 * SEC);
-export const SETTLEMENT_DEADLINE_SEC = +(process.env.SETTLEMENT_DEADLINE_SEC ?? 15 * MIN);
+export const SETTLEMENT_DEADLINE = +(process.env.SETTLEMENT_DEADLINE ?? 90 * MIN);

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,7 @@ import winston from "winston";
 import { Provider, Wallet as ZkSyncWallet } from "zksync-ethers";
 import { IL1SharedBridge__factory } from "zksync-ethers/build/typechain";
 
-import { SETTLEMENT_DEADLINE_SEC } from "./configs";
+import { SETTLEMENT_DEADLINE } from "./configs";
 import { DepositFlow } from "./deposit";
 import { DepositUserFlow } from "./depositUsers";
 import { recordWalletInfo } from "./flowMetric";
@@ -102,7 +102,7 @@ const main = async () => {
     if (process.env.FLOW_SETTLEMENT_ENABLE === "1") {
       const l1Provider = new Provider(unwrap(process.env.CHAIN_L1_RPC_URL));
       const settlementIntervalMs = +(process.env.FLOW_SETTLEMENT_INTERVAL ?? SEC);
-      new SettlementFlow(l2Provider, l1Provider, settlementIntervalMs, SETTLEMENT_DEADLINE_SEC).run();
+      new SettlementFlow(l2Provider, l1Provider, settlementIntervalMs, SETTLEMENT_DEADLINE).run();
       enabledFlows++;
     }
   } else {
@@ -203,7 +203,7 @@ const main = async () => {
     if (process.env.FLOW_SETTLEMENT_ENABLE === "1") {
       const l1Provider = new Provider(unwrap(process.env.CHAIN_L1_RPC_URL));
       const settlementIntervalMs = +(process.env.FLOW_SETTLEMENT_INTERVAL ?? 1000);
-      new SettlementFlow(l2Provider, l1Provider, settlementIntervalMs, SETTLEMENT_DEADLINE_SEC).run();
+      new SettlementFlow(l2Provider, l1Provider, settlementIntervalMs, SETTLEMENT_DEADLINE).run();
       enabledFlows++;
     }
   }

--- a/src/settlement.ts
+++ b/src/settlement.ts
@@ -17,7 +17,7 @@ export class SettlementFlow extends BaseFlow {
     private l2Provider: ZkSyncProvider,
     private l1Provider: Provider,
     private intervalMs: number,
-    private settlementDeadlineSec: number
+    private settlementDeadline: number
   ) {
     super(FLOW_NAME);
     this.metricSettlementAge = new Gauge({
@@ -72,8 +72,10 @@ export class SettlementFlow extends BaseFlow {
               this.metricSettlementAge.set(settlementAgeSec);
 
               // Check if it exceeds the deadline
-              if (settlementAgeSec > this.settlementDeadlineSec) {
-                throw new Error(`Settlement age ${settlementAgeSec}s exceeds deadline ${this.settlementDeadlineSec}s`);
+              if (settlementAgeSec * SEC > this.settlementDeadline) {
+                throw new Error(
+                  `Settlement age ${settlementAgeSec}s exceeds deadline ${this.settlementDeadline / 1000}s`
+                );
               }
             } else {
               // No unsettled blocks


### PR DESCRIPTION
This PR fixes a bug where settlement deadline was 15.000 minutes - not just 15 minutes.

But 15 minutes is not attainable on e.g. mainnet-dawn where we seal batches each 1hour. The short-term solution is to increase the deadline on SLI side to 1.5 hours. We are still discussing longer-term. I updated the SLIs notion [page](https://www.notion.so/matterlabs/Measuring-availability-SLIs-and-SLOs-261a48363f2380939067dde8af1af4b6?source=copy_link#2cca48363f238069a427dd68a42d5ecf).