### PR TITLE
fix: improve logging and provider usage

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import "dotenv/config";
-import { ethers, Wallet as EthersWallet, JsonRpcApiProviderOptions } from "ethers";
+import { ethers, Wallet as EthersWallet } from "ethers";
 import express from "express";
 import { collectDefaultMetrics, register } from "prom-client";
 import winston from "winston";
@@ -23,12 +23,13 @@ import { WithdrawalFlow } from "./withdrawal";
 import { WithdrawalFinalizeFlow } from "./withdrawalFinalize";
 
 import type { PrividiumTokenStore } from "./prividiumAuth";
+import type { JsonRpcApiProviderOptions } from "ethers";
 
 function getProviderOptions(opts?: JsonRpcApiProviderOptions): JsonRpcApiProviderOptions {
   return {
     ...opts,
     staticNetwork: true, // avoid repeated eth_chainId calls
-  }
+  };
 }
 
 const main = async () => {
@@ -37,9 +38,13 @@ const main = async () => {
 
   // For ZKsync OS chains we cannot use `LoggingZkSyncProvider` for getting tx receipt
   // because format of L2 to L1 logs is different. So we create a separate ethers provider for that.
-  const l2EthersProvider = new LoggingEthersJsonRpcProvider(unwrap(process.env.CHAIN_RPC_URL), undefined, getProviderOptions({
-    pollingInterval: 100,
-  }));
+  const l2EthersProvider = new LoggingEthersJsonRpcProvider(
+    unwrap(process.env.CHAIN_RPC_URL),
+    undefined,
+    getProviderOptions({
+      pollingInterval: 100,
+    })
+  );
   const zkos_mode = process.env.ZKOS_MODE === "1";
 
   let enabledFlows = 0;
@@ -207,7 +212,11 @@ const main = async () => {
     if (process.env.FLOW_WITHDRAWAL_FINALIZE_ENABLE === "1") {
       // We need a wallet with both L2 and L1 providers for withdrawal finalization
       // Create a new wallet with L1 provider
-      const l1ProviderForWithdrawal = new LoggingZkSyncProvider(unwrap(process.env.CHAIN_L1_RPC_URL), undefined, getProviderOptions());
+      const l1ProviderForWithdrawal = new LoggingZkSyncProvider(
+        unwrap(process.env.CHAIN_L1_RPC_URL),
+        undefined,
+        getProviderOptions()
+      );
       const walletForWithdrawals = new ZkSyncWallet(
         unwrap(process.env.WALLET_KEY),
         l2Provider,

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import "dotenv/config";
-import { ethers, Wallet as EthersWallet } from "ethers";
+import { ethers, Wallet as EthersWallet, JsonRpcApiProviderOptions } from "ethers";
 import express from "express";
 import { collectDefaultMetrics, register } from "prom-client";
 import winston from "winston";
@@ -24,14 +24,22 @@ import { WithdrawalFinalizeFlow } from "./withdrawalFinalize";
 
 import type { PrividiumTokenStore } from "./prividiumAuth";
 
+function getProviderOptions(opts?: JsonRpcApiProviderOptions): JsonRpcApiProviderOptions {
+  return {
+    ...opts,
+    staticNetwork: true, // avoid repeated eth_chainId calls
+  }
+}
+
 const main = async () => {
   setupLogger(process.env.NODE_ENV, process.env.LOG_LEVEL);
-  const l2Provider = new LoggingZkSyncProvider(unwrap(process.env.CHAIN_RPC_URL));
+  const l2Provider = new LoggingZkSyncProvider(unwrap(process.env.CHAIN_RPC_URL), undefined, getProviderOptions());
 
   // For ZKsync OS chains we cannot use `LoggingZkSyncProvider` for getting tx receipt
   // because format of L2 to L1 logs is different. So we create a separate ethers provider for that.
-  const l2EthersProvider = new LoggingEthersJsonRpcProvider(unwrap(process.env.CHAIN_RPC_URL));
-  l2EthersProvider.pollingInterval = 100;
+  const l2EthersProvider = new LoggingEthersJsonRpcProvider(unwrap(process.env.CHAIN_RPC_URL), undefined, getProviderOptions({
+    pollingInterval: 100,
+  }));
   const zkos_mode = process.env.ZKOS_MODE === "1";
 
   let enabledFlows = 0;
@@ -76,7 +84,7 @@ const main = async () => {
     }
 
     if (process.env.FLOW_DEPOSIT_ENABLE === "1") {
-      const l1Provider = new Provider(unwrap(process.env.CHAIN_L1_RPC_URL));
+      const l1Provider = new Provider(unwrap(process.env.CHAIN_L1_RPC_URL), undefined, getProviderOptions());
       l2Provider.setL1Provider(l1Provider);
 
       const walletDeposit = new ZkSyncWallet(unwrap(process.env.WALLET_KEY), l2Provider, l1Provider);
@@ -122,7 +130,7 @@ const main = async () => {
 
     // Settlement flow
     if (process.env.FLOW_SETTLEMENT_ENABLE === "1") {
-      const l1Provider = new Provider(unwrap(process.env.CHAIN_L1_RPC_URL));
+      const l1Provider = new Provider(unwrap(process.env.CHAIN_L1_RPC_URL), undefined, getProviderOptions());
       const settlementIntervalMs = +(process.env.FLOW_SETTLEMENT_INTERVAL ?? SEC);
       new SettlementFlow(l2Provider, l1Provider, settlementIntervalMs, SETTLEMENT_DEADLINE).run();
       enabledFlows++;
@@ -148,7 +156,7 @@ const main = async () => {
     }
 
     if (process.env.FLOW_DEPOSIT_ENABLE === "1" || process.env.FLOW_DEPOSIT_USER_ENABLE === "1") {
-      const l1Provider = new Provider(unwrap(process.env.CHAIN_L1_RPC_URL));
+      const l1Provider = new Provider(unwrap(process.env.CHAIN_L1_RPC_URL), undefined, getProviderOptions());
       const walletDeposit = new ZkSyncWallet(unwrap(process.env.WALLET_KEY), l2Provider, l1Provider);
       const l1BridgeContracts = await walletDeposit.getL1BridgeContracts();
       const chainId = (await walletDeposit.provider.getNetwork()).chainId;
@@ -199,7 +207,7 @@ const main = async () => {
     if (process.env.FLOW_WITHDRAWAL_FINALIZE_ENABLE === "1") {
       // We need a wallet with both L2 and L1 providers for withdrawal finalization
       // Create a new wallet with L1 provider
-      const l1ProviderForWithdrawal = new LoggingZkSyncProvider(unwrap(process.env.CHAIN_L1_RPC_URL));
+      const l1ProviderForWithdrawal = new LoggingZkSyncProvider(unwrap(process.env.CHAIN_L1_RPC_URL), undefined, getProviderOptions());
       const walletForWithdrawals = new ZkSyncWallet(
         unwrap(process.env.WALLET_KEY),
         l2Provider,
@@ -223,7 +231,7 @@ const main = async () => {
 
     // Settlement flow
     if (process.env.FLOW_SETTLEMENT_ENABLE === "1") {
-      const l1Provider = new Provider(unwrap(process.env.CHAIN_L1_RPC_URL));
+      const l1Provider = new Provider(unwrap(process.env.CHAIN_L1_RPC_URL), undefined, getProviderOptions());
       const settlementIntervalMs = +(process.env.FLOW_SETTLEMENT_INTERVAL ?? 1000);
       new SettlementFlow(l2Provider, l1Provider, settlementIntervalMs, SETTLEMENT_DEADLINE).run();
       enabledFlows++;

--- a/src/rpcLoggingProvider.ts
+++ b/src/rpcLoggingProvider.ts
@@ -3,7 +3,7 @@ import winston from "winston";
 import { Provider as ZkSyncProvider } from "zksync-ethers";
 import { IBridgehub__factory } from "zksync-ethers/build/typechain";
 
-import type { Networkish, Provider as EthersProvider, TransactionReceipt } from "ethers";
+import type { Networkish, Provider as EthersProvider, TransactionReceipt, JsonRpcApiProviderOptions } from "ethers";
 import type { Fee, TransactionRequest } from "zksync-ethers/build/types";
 
 /** Optional auth token getter for Prividium (Authorization: Bearer). */
@@ -16,8 +16,8 @@ class AuthableEthersJsonRpcProvider extends EthersJsonRpcProvider {
   declare readonly rpcUrl?: string;
   getAuthToken?: AuthTokenGetter;
 
-  constructor(url?: string, network?: Networkish) {
-    super(url, network);
+  constructor(url?: string, network?: Networkish, options?: JsonRpcApiProviderOptions) {
+    super(url, network, options);
     this.rpcUrl = url;
   }
 
@@ -35,8 +35,8 @@ class ZkSyncOsProvider extends ZkSyncProvider {
   protected readonly rpcUrl: string;
   getAuthToken?: AuthTokenGetter;
 
-  constructor(url: string) {
-    super(url);
+  constructor(url: string, network?: Networkish, options?: JsonRpcApiProviderOptions) {
+    super(url, network, options);
     this.rpcUrl = url;
   }
 
@@ -118,6 +118,13 @@ const LoggingProviderMixing = <TBase extends Ctor<EthersJsonRpcProvider>>(Base: 
 
         const duration = Date.now() - startTime;
         winston.debug(`[JSON-RPC Response] ID: ${id} Method: ${method} Duration: ${duration}ms`, {
+          rpcResponse: {
+            id,
+            method,
+          },
+        });
+        // Log the full response result at a lower level to avoid cluttering logs, but still have it available for debugging when needed
+        winston.silly(`[JSON-RPC Response Result] ID: ${id} Method: ${method}`, {
           rpcResponse: {
             id,
             method,


### PR DESCRIPTION
This PR:
- enables `staticNetwork: true` across L1/L2 providers to avoid repeated `eth_chainId` calls.
- splits RPC response logging:
  - `debug`: request metadata (id, method, duration)
  - `silly`: full JSON-RPC result payload

This change is fully backward compatible and does not require any specific rollout instructions.
Set `LOG_LEVEL` to `silly` if you need to check full RPC results for troubleshooting.