### PR TITLE
fix: deposit L1 provider wiring with ZKOS_MODE=0

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -164,6 +164,7 @@ const main = async () => {
 
     if (process.env.FLOW_DEPOSIT_ENABLE === "1" || process.env.FLOW_DEPOSIT_USER_ENABLE === "1") {
       const l1Provider = new Provider(unwrap(process.env.CHAIN_L1_RPC_URL), undefined, getProviderOptions());
+      l2Provider.setL1Provider(l1Provider);
       const walletDeposit = await createZkSyncWallet(unwrap(process.env.WALLET_KEY), l2Provider, l1Provider);
       const l1BridgeContracts = await walletDeposit.getL1BridgeContracts();
       const chainId = (await walletDeposit.provider.getNetwork()).chainId;


### PR DESCRIPTION
## Summary

This bug was introduced about 8 months ago. deposit flows failed with: 

```
[depositUser] watchdog deposit tx error: contract runner does not support calling (operation="call", code=UNSUPPORTED_OPERATION, version=6.13.5)
```

To fix this, a missing call to `l2Provider.setL1Provider` was added.

## Root cause

The custom `LoggingZkSyncProvider` overrides `getBaseTokenContractAddress()` and reads Bridgehub through its internal L1 provider. The ZKOS branch set that provider, but the non-ZKOS deposit branch did not, so deposit preparation could fail with `contract runner does not support calling`.

## Validation
- `yarn run typecheck`
- `yarn run lint:check`
- Ran local devmode Era watchdog deposit flow with only `FLOW_DEPOSIT_ENABLE=1`; observed `watchdog_status{flow="deposit"} 1`, L1 tx `0x48de0c7c022f994b7b6351bd76a70b6d99242cca5d43dacee7b21a2ccf3c555b`, and L2 tx `0x250dd3da8c2d1186e8751e71f34d0d96ec8b2b7c9b26a2b7b2038146ca1fc71a` with L2 receipt status `0x1`.