### PR TITLE
fix: stop waitForTransaction listener leak

### DIFF
--- a/src/deposit.ts
+++ b/src/deposit.ts
@@ -143,7 +143,7 @@ export class DepositFlow extends DepositBaseFlow {
         stepName: STEPS.l2_execution,
         stepTimeoutMs: PRIORITY_OP_TIMEOUT,
         fn: async ({ recordStepGasPrice, recordStepGas, recordStepGasCost }) => {
-          const receipt = unwrap(await this.l2EthersProvider.waitForTransaction(l2TxHash, 1));
+          const receipt = unwrap(await this.l2EthersProvider.waitForTransaction(l2TxHash, 1, PRIORITY_OP_TIMEOUT));
           recordStepGasPrice(unwrap(receipt.gasPrice));
           recordStepGas(unwrap(receipt.gasUsed));
           recordStepGasCost(unwrap(receipt.gasUsed) * unwrap(receipt.gasPrice));

--- a/src/rpcLoggingProvider.ts
+++ b/src/rpcLoggingProvider.ts
@@ -3,7 +3,7 @@ import winston from "winston";
 import { Provider as ZkSyncProvider } from "zksync-ethers";
 import { IBridgehub__factory } from "zksync-ethers/build/typechain";
 
-import type { Networkish, Provider as EthersProvider, JsonRpcApiProviderOptions } from "ethers";
+import type { Networkish, Provider as EthersProvider, TransactionReceipt, JsonRpcApiProviderOptions } from "ethers";
 import type { Fee, TransactionRequest } from "zksync-ethers/build/types";
 
 /** Optional auth token getter for Prividium (Authorization: Bearer). */
@@ -149,6 +149,51 @@ const LoggingProviderMixing = <TBase extends Ctor<EthersJsonRpcProvider>>(Base: 
 
         throw error;
       }
+    }
+
+    override async waitForTransaction(
+      hash: string,
+      _confirms?: null | number,
+      timeout?: null | number
+    ): Promise<null | TransactionReceipt> {
+      const confirms = _confirms != null ? _confirms : 1;
+      if (confirms === 0) {
+        return this.getTransactionReceipt(hash);
+      }
+
+      return new Promise((resolve, reject) => {
+        let timer: null | NodeJS.Timeout = null;
+
+        const listener = async (receipt: TransactionReceipt) => {
+          await this.once(hash, listener);
+          try {
+            if ((await receipt.confirmations()) >= confirms) {
+              resolve(receipt);
+              await this.off(hash, listener);
+              if (timer) {
+                clearTimeout(timer);
+                timer = null;
+              }
+              return;
+            }
+          } catch (error) {
+            winston.error("Error in waitForTransaction", error);
+          }
+        };
+
+        if (timeout != null) {
+          timer = setTimeout(() => {
+            if (timer == null) {
+              return;
+            }
+            timer = null;
+            this.off(hash, listener);
+            reject(new Error("timeout"));
+          }, timeout);
+        }
+
+        this.once(hash, listener);
+      });
     }
   };
 };

--- a/src/rpcLoggingProvider.ts
+++ b/src/rpcLoggingProvider.ts
@@ -87,18 +87,6 @@ function getRpcUrl(provider: any): string | undefined {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Ctor<T = object> = new (...args: any[]) => T;
 
-// `isLogLevelEnabled` isn't typed on the default-export shape, so compare
-// priorities ourselves. Higher number = more verbose; a level is enabled when
-// its priority is <= the configured logger level's priority.
-function isLogLevelEnabled(level: string): boolean {
-  const levels = winston.config.npm.levels as Record<string, number>;
-  const configured = (winston as unknown as { level?: string }).level ?? "info";
-  const target = levels[level];
-  const current = levels[configured];
-  if (target == null || current == null) return true;
-  return target <= current;
-}
-
 const LoggingProviderMixing = <TBase extends Ctor<EthersJsonRpcProvider>>(Base: TBase) => {
   return class LoggingProvider extends Base {
     private requestId: number = 1;
@@ -107,15 +95,13 @@ const LoggingProviderMixing = <TBase extends Ctor<EthersJsonRpcProvider>>(Base: 
       const id = this.requestId++;
       const self = this as typeof this & { getAuthToken?: AuthTokenGetter };
 
-      if (isLogLevelEnabled("debug")) {
-        winston.debug(`[JSON-RPC Request] ID: ${id} Method: ${method}`, {
-          rpcRequest: {
-            id,
-            method,
-            params: JSON.stringify(params, (_, value) => (typeof value === "bigint" ? value.toString() : value)),
-          },
-        });
-      }
+      winston.debug(`[JSON-RPC Request] ID: ${id} Method: ${method}`, {
+        rpcRequest: {
+          id,
+          method,
+          params: JSON.stringify(params, (_, value) => (typeof value === "bigint" ? value.toString() : value)),
+        },
+      });
 
       const startTime = Date.now();
       try {
@@ -131,24 +117,20 @@ const LoggingProviderMixing = <TBase extends Ctor<EthersJsonRpcProvider>>(Base: 
         }
 
         const duration = Date.now() - startTime;
-        if (isLogLevelEnabled("debug")) {
-          winston.debug(`[JSON-RPC Response] ID: ${id} Method: ${method} Duration: ${duration}ms`, {
-            rpcResponse: {
-              id,
-              method,
-            },
-          });
-        }
+        winston.debug(`[JSON-RPC Response] ID: ${id} Method: ${method} Duration: ${duration}ms`, {
+          rpcResponse: {
+            id,
+            method,
+          },
+        });
         // Log the full response result at a lower level to avoid cluttering logs, but still have it available for debugging when needed
-        if (isLogLevelEnabled("silly")) {
-          winston.silly(`[JSON-RPC Response Result] ID: ${id} Method: ${method}`, {
-            rpcResponse: {
-              id,
-              method,
-              result: JSON.stringify(result, (_, value) => (typeof value === "bigint" ? value.toString() : value)),
-            },
-          });
-        }
+        winston.silly(`[JSON-RPC Response Result] ID: ${id} Method: ${method}`, {
+          rpcResponse: {
+            id,
+            method,
+            result: JSON.stringify(result, (_, value) => (typeof value === "bigint" ? value.toString() : value)),
+          },
+        });
 
         return result;
         // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/rpcLoggingProvider.ts
+++ b/src/rpcLoggingProvider.ts
@@ -3,7 +3,7 @@ import winston from "winston";
 import { Provider as ZkSyncProvider } from "zksync-ethers";
 import { IBridgehub__factory } from "zksync-ethers/build/typechain";
 
-import type { Networkish, Provider as EthersProvider, TransactionReceipt, JsonRpcApiProviderOptions } from "ethers";
+import type { Networkish, Provider as EthersProvider, JsonRpcApiProviderOptions } from "ethers";
 import type { Fee, TransactionRequest } from "zksync-ethers/build/types";
 
 /** Optional auth token getter for Prividium (Authorization: Bearer). */
@@ -87,6 +87,18 @@ function getRpcUrl(provider: any): string | undefined {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Ctor<T = object> = new (...args: any[]) => T;
 
+// `isLogLevelEnabled` isn't typed on the default-export shape, so compare
+// priorities ourselves. Higher number = more verbose; a level is enabled when
+// its priority is <= the configured logger level's priority.
+function isLogLevelEnabled(level: string): boolean {
+  const levels = winston.config.npm.levels as Record<string, number>;
+  const configured = (winston as unknown as { level?: string }).level ?? "info";
+  const target = levels[level];
+  const current = levels[configured];
+  if (target == null || current == null) return true;
+  return target <= current;
+}
+
 const LoggingProviderMixing = <TBase extends Ctor<EthersJsonRpcProvider>>(Base: TBase) => {
   return class LoggingProvider extends Base {
     private requestId: number = 1;
@@ -95,13 +107,15 @@ const LoggingProviderMixing = <TBase extends Ctor<EthersJsonRpcProvider>>(Base: 
       const id = this.requestId++;
       const self = this as typeof this & { getAuthToken?: AuthTokenGetter };
 
-      winston.debug(`[JSON-RPC Request] ID: ${id} Method: ${method}`, {
-        rpcRequest: {
-          id,
-          method,
-          params: JSON.stringify(params, (_, value) => (typeof value === "bigint" ? value.toString() : value)),
-        },
-      });
+      if (isLogLevelEnabled("debug")) {
+        winston.debug(`[JSON-RPC Request] ID: ${id} Method: ${method}`, {
+          rpcRequest: {
+            id,
+            method,
+            params: JSON.stringify(params, (_, value) => (typeof value === "bigint" ? value.toString() : value)),
+          },
+        });
+      }
 
       const startTime = Date.now();
       try {
@@ -117,20 +131,24 @@ const LoggingProviderMixing = <TBase extends Ctor<EthersJsonRpcProvider>>(Base: 
         }
 
         const duration = Date.now() - startTime;
-        winston.debug(`[JSON-RPC Response] ID: ${id} Method: ${method} Duration: ${duration}ms`, {
-          rpcResponse: {
-            id,
-            method,
-          },
-        });
+        if (isLogLevelEnabled("debug")) {
+          winston.debug(`[JSON-RPC Response] ID: ${id} Method: ${method} Duration: ${duration}ms`, {
+            rpcResponse: {
+              id,
+              method,
+            },
+          });
+        }
         // Log the full response result at a lower level to avoid cluttering logs, but still have it available for debugging when needed
-        winston.silly(`[JSON-RPC Response Result] ID: ${id} Method: ${method}`, {
-          rpcResponse: {
-            id,
-            method,
-            result: JSON.stringify(result, (_, value) => (typeof value === "bigint" ? value.toString() : value)),
-          },
-        });
+        if (isLogLevelEnabled("silly")) {
+          winston.silly(`[JSON-RPC Response Result] ID: ${id} Method: ${method}`, {
+            rpcResponse: {
+              id,
+              method,
+              result: JSON.stringify(result, (_, value) => (typeof value === "bigint" ? value.toString() : value)),
+            },
+          });
+        }
 
         return result;
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -149,51 +167,6 @@ const LoggingProviderMixing = <TBase extends Ctor<EthersJsonRpcProvider>>(Base: 
 
         throw error;
       }
-    }
-
-    override async waitForTransaction(
-      hash: string,
-      _confirms?: null | number,
-      timeout?: null | number
-    ): Promise<null | TransactionReceipt> {
-      const confirms = _confirms != null ? _confirms : 1;
-      if (confirms === 0) {
-        return this.getTransactionReceipt(hash);
-      }
-
-      return new Promise((resolve, reject) => {
-        let timer: null | NodeJS.Timeout = null;
-
-        const listener = async (receipt: TransactionReceipt) => {
-          await this.once(hash, listener);
-          try {
-            if ((await receipt.confirmations()) >= confirms) {
-              resolve(receipt);
-              await this.off(hash, listener);
-              if (timer) {
-                clearTimeout(timer);
-                timer = null;
-              }
-              return;
-            }
-          } catch (error) {
-            winston.error("Error in waitForTransaction", error);
-          }
-        };
-
-        if (timeout != null) {
-          timer = setTimeout(() => {
-            if (timer == null) {
-              return;
-            }
-            timer = null;
-            this.off(hash, listener);
-            reject(new Error("timeout"));
-          }, timeout);
-        }
-
-        this.once(hash, listener);
-      });
     }
   };
 };

--- a/src/transfer.ts
+++ b/src/transfer.ts
@@ -88,7 +88,7 @@ export class SimpleTxFlow extends BaseFlow {
         fn: async ({ recordStepGas, recordStepGasPrice, recordStepGasCost }) => {
           let receipt;
           if (this.l2EthersProvider != null) {
-            receipt = unwrap(await this.l2EthersProvider.waitForTransaction(txResponse.hash, 1));
+            receipt = unwrap(await this.l2EthersProvider.waitForTransaction(txResponse.hash, 1, L2_EXECUTION_TIMEOUT));
           } else {
             receipt = unwrap(await txResponse.wait(1));
           }

--- a/src/withdrawal.ts
+++ b/src/withdrawal.ts
@@ -67,7 +67,9 @@ export class WithdrawalFlow extends WithdrawalBaseFlow {
           recordStepGasPrice: (price: BigNumberish) => void;
           recordStepGasCost: (cost: BigNumberish) => void;
         }) => {
-          const receipt = unwrap(await this.l2EthersProvider.waitForTransaction(withdrawalHandle.hash));
+          const receipt = unwrap(
+            await this.l2EthersProvider.waitForTransaction(withdrawalHandle.hash, 1, L2_EXECUTION_TIMEOUT)
+          );
           recordStepGas(unwrap(receipt.gasUsed));
           recordStepGasPrice(unwrap(receipt.gasPrice));
           recordStepGasCost(BigInt(unwrap(receipt.gasUsed)) * BigInt(unwrap(receipt.gasPrice)));


### PR DESCRIPTION
## Summary
The watchdog showed CPU spikes correlating with steadily climbing RAM. The cause is in `rpcLoggingProvider.ts`'s custom `waitForTransaction` (added in d2e2658 to work around an ethers interlacing bug where the auto-removed `.once` listener can disappear during an in-flight `confirmations()` call, missing the next block).

The override is fine — but its cleanup (`this.off(hash, listener)`) only runs inside the `setTimeout` branch, which is guarded by `if (timeout != null)`. The three callers passed no inner `timeout` and relied on the outer `withTimeout` wrapper in `stepExecution`. `withTimeout` only rejects the outer promise; it cannot cancel the inner one. So every time a step timed out, a listener stayed registered on the shared provider. With `pollingInterval: 100` on `l2EthersProvider`, each leaked listener polled ~10x/sec, growing CPU and RAM in lockstep over the service's lifetime.

Fix:
- Pass the step timeout (`PRIORITY_OP_TIMEOUT` / `L2_EXECUTION_TIMEOUT`) to `waitForTransaction` at the three callsites that previously omitted it (`deposit.ts`, `withdrawal.ts`, `transfer.ts`). `depositBase.ts` already passed one.
- Keep the override as-is; its `setTimeout`/`off` path is the cleanup that the inner `timeout` argument unlocks.

`pollingInterval: 100` was left as-is — that's an intentional behavior choice.

## Test plan
- [x] `yarn typecheck`
- [x] `yarn lint:check`
- [ ] Deploy to a staging chain and watch heap RSS over 24h to confirm it no longer drifts up. Watch CPU under tx-timeout conditions (e.g. throttle the L2 RPC, or force priority-op timeouts).
- [ ] Confirm normal-path behavior: deposits / withdrawals / transfers still wait correctly for receipts and surface receipts to gas metrics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)