### PR TITLE
fix: gate RPC log JSON.stringify and clean up waitForTransaction listener on error

### DIFF
--- a/src/rpcLoggingProvider.ts
+++ b/src/rpcLoggingProvider.ts
@@ -87,6 +87,18 @@ function getRpcUrl(provider: any): string | undefined {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Ctor<T = object> = new (...args: any[]) => T;
 
+// `isLogLevelEnabled` isn't typed on the default-export shape, so compare
+// priorities ourselves. Higher number = more verbose; a level is enabled when
+// its priority is <= the configured logger level's priority.
+function isLogLevelEnabled(level: string): boolean {
+  const levels = winston.config.npm.levels as Record<string, number>;
+  const configured = (winston as unknown as { level?: string }).level ?? "info";
+  const target = levels[level];
+  const current = levels[configured];
+  if (target == null || current == null) return true;
+  return target <= current;
+}
+
 const LoggingProviderMixing = <TBase extends Ctor<EthersJsonRpcProvider>>(Base: TBase) => {
   return class LoggingProvider extends Base {
     private requestId: number = 1;
@@ -95,13 +107,15 @@ const LoggingProviderMixing = <TBase extends Ctor<EthersJsonRpcProvider>>(Base: 
       const id = this.requestId++;
       const self = this as typeof this & { getAuthToken?: AuthTokenGetter };
 
-      winston.debug(`[JSON-RPC Request] ID: ${id} Method: ${method}`, {
-        rpcRequest: {
-          id,
-          method,
-          params: JSON.stringify(params, (_, value) => (typeof value === "bigint" ? value.toString() : value)),
-        },
-      });
+      if (isLogLevelEnabled("debug")) {
+        winston.debug(`[JSON-RPC Request] ID: ${id} Method: ${method}`, {
+          rpcRequest: {
+            id,
+            method,
+            params: JSON.stringify(params, (_, value) => (typeof value === "bigint" ? value.toString() : value)),
+          },
+        });
+      }
 
       const startTime = Date.now();
       try {
@@ -117,20 +131,24 @@ const LoggingProviderMixing = <TBase extends Ctor<EthersJsonRpcProvider>>(Base: 
         }
 
         const duration = Date.now() - startTime;
-        winston.debug(`[JSON-RPC Response] ID: ${id} Method: ${method} Duration: ${duration}ms`, {
-          rpcResponse: {
-            id,
-            method,
-          },
-        });
+        if (isLogLevelEnabled("debug")) {
+          winston.debug(`[JSON-RPC Response] ID: ${id} Method: ${method} Duration: ${duration}ms`, {
+            rpcResponse: {
+              id,
+              method,
+            },
+          });
+        }
         // Log the full response result at a lower level to avoid cluttering logs, but still have it available for debugging when needed
-        winston.silly(`[JSON-RPC Response Result] ID: ${id} Method: ${method}`, {
-          rpcResponse: {
-            id,
-            method,
-            result: JSON.stringify(result, (_, value) => (typeof value === "bigint" ? value.toString() : value)),
-          },
-        });
+        if (isLogLevelEnabled("silly")) {
+          winston.silly(`[JSON-RPC Response Result] ID: ${id} Method: ${method}`, {
+            rpcResponse: {
+              id,
+              method,
+              result: JSON.stringify(result, (_, value) => (typeof value === "bigint" ? value.toString() : value)),
+            },
+          });
+        }
 
         return result;
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -178,6 +196,12 @@ const LoggingProviderMixing = <TBase extends Ctor<EthersJsonRpcProvider>>(Base: 
             }
           } catch (error) {
             winston.error("Error in waitForTransaction", error);
+            await this.off(hash, listener);
+            if (timer) {
+              clearTimeout(timer);
+              timer = null;
+            }
+            reject(error);
           }
         };
 


### PR DESCRIPTION
## Summary
Two related changes to `src/rpcLoggingProvider.ts` to address the steady ~80% CPU and the OOM hit on `main` after PR #68. The OOM trace showed V8 at the heap ceiling with `mu=0.088` — GC-thrash with a small live-set leak.

- **Gate the per-call `JSON.stringify` of RPC request params and full response result behind log-level checks.** Previously the metadata object (and the inner `JSON.stringify` on params/result) was built unconditionally to hand to winston, then dropped at INFO. With `pollingInterval: 100` on `l2EthersProvider` that's ~10 small string allocations per second baseline plus large allocations per `eth_getLogs` response — enough churn to keep mark-compact running near the heap limit.
- **Make the `waitForTransaction` override's catch branch deterministic.** It now `off()`s the listener, clears the timer, and rejects the outer promise. The listener has already re-registered itself one line above the `try`, so a transient `receipt.confirmations()` error would otherwise keep the registration armed for the full timeout window (up to `PRIORITY_OP_TIMEOUT = 15min`), retained per receipt. Callers already retry on the next iteration, so losing the in-flight retry is fine.

The override itself stays (the original interlacing-bug workaround from d2e2658 is still needed).

## Test plan
- [x] `yarn typecheck`
- [x] `yarn lint:check`
- [ ] Deploy to a staging chain and watch CPU + heap RSS over 24h. Expect baseline CPU drop and no monotonic heap growth.
- [ ] Optional: capture heap snapshot under load to confirm `Listener` / `Log[]` retention is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)