### PR TITLE
fix: memory and cpu leak

### DIFF
--- a/src/deposit.ts
+++ b/src/deposit.ts
@@ -199,7 +199,7 @@ export class DepositFlow extends DepositBaseFlow {
             throw new Error(`Unreachable code branch: ${_exhaustiveCheck}`);
           }
         }
-        if (result == Status.OK) break;
+        if (result == Status.OK || result == Status.SKIP) break;
       }
       await nextExecutionWait;
     }

--- a/src/depositUsers.ts
+++ b/src/depositUsers.ts
@@ -173,7 +173,7 @@ export class DepositUserFlow extends DepositBaseFlow {
                 throw new Error(`Unexpected result ${result}`);
               }
             }
-            if (result === Status.OK) {
+            if (result === Status.OK || result === Status.SKIP) {
               break;
             }
             await timeoutPromise(DEPOSIT_RETRY_INTERVAL);

--- a/src/main.ts
+++ b/src/main.ts
@@ -43,7 +43,7 @@ const main = async () => {
     unwrap(process.env.CHAIN_RPC_URL),
     undefined,
     getProviderOptions({
-      pollingInterval: 100,
+      pollingInterval: 4000,
     })
   );
   const zkos_mode = process.env.ZKOS_MODE === "1";

--- a/src/rpcLoggingProvider.ts
+++ b/src/rpcLoggingProvider.ts
@@ -99,7 +99,6 @@ const LoggingProviderMixing = <TBase extends Ctor<EthersJsonRpcProvider>>(Base: 
         rpcRequest: {
           id,
           method,
-          params: JSON.stringify(params, (_, value) => (typeof value === "bigint" ? value.toString() : value)),
         },
       });
 
@@ -123,14 +122,17 @@ const LoggingProviderMixing = <TBase extends Ctor<EthersJsonRpcProvider>>(Base: 
             method,
           },
         });
-        // Log the full response result at a lower level to avoid cluttering logs, but still have it available for debugging when needed
-        winston.silly(`[JSON-RPC Response Result] ID: ${id} Method: ${method}`, {
-          rpcResponse: {
-            id,
-            method,
-            result: JSON.stringify(result, (_, value) => (typeof value === "bigint" ? value.toString() : value)),
-          },
-        });
+        // Log the full response result at a lower level to avoid cluttering logs, but still have it available for debugging when needed.
+        // Guard with level check to avoid expensive JSON.stringify on every RPC call in production.
+        if (winston.config.npm.levels[winston.level] >= winston.config.npm.levels["silly"]) {
+          winston.silly(`[JSON-RPC Response Result] ID: ${id} Method: ${method}`, {
+            rpcResponse: {
+              id,
+              method,
+              result: JSON.stringify(result, (_, value) => (typeof value === "bigint" ? value.toString() : value)),
+            },
+          });
+        }
 
         return result;
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -165,19 +167,26 @@ const LoggingProviderMixing = <TBase extends Ctor<EthersJsonRpcProvider>>(Base: 
         let timer: null | NodeJS.Timeout = null;
 
         const listener = async (receipt: TransactionReceipt) => {
-          await this.once(hash, listener);
           try {
             if ((await receipt.confirmations()) >= confirms) {
               resolve(receipt);
-              await this.off(hash, listener);
               if (timer) {
                 clearTimeout(timer);
                 timer = null;
               }
               return;
             }
+            // Not enough confirmations yet — re-register for the next block
+            await this.once(hash, listener);
           } catch (error) {
             winston.error("Error in waitForTransaction", error);
+            // Clean up: reject the promise so callers don't hang,
+            // and clear the timer so nothing is left dangling.
+            if (timer) {
+              clearTimeout(timer);
+              timer = null;
+            }
+            reject(error);
           }
         };
 


### PR DESCRIPTION
Fix 1 — pollingInterval: 100 → 4000 (main.ts) — Primary CPU culprit
The ethers provider was polling eth_blockNumber every 100ms (10 times/sec). Each pending waitForTransaction also fires eth_getTransactionReceipt on every poll. With multiple flows active, this generates dozens of RPC calls per second, each involving JSON parsing, serialization, and logging — saturating CPU. Changed to 4000ms, which is ethers' default and more than adequate for a watchdog.

NOTE: not sure if this makes sense or if the 100ms polling was intended.

Fix 2 — Listener leak in waitForTransaction (rpcLoggingProvider.ts)
this.once() now only re-registers when more confirmations are needed, and the error path rejects the promise + clears the timer.

Fix 3 — Infinite SKIP retry loops (deposit.ts, depositUsers.ts)
When gas price exceeded the limit, executeWatchdogDeposit() returned Status.SKIP, but the retry loop only broke on Status.OK. Since SKIP doesn't increment attempt, the inner loop ran forever (retrying every 30s but never exiting). The outer loop's interval timer would have long expired, so iterations would stack up logically. Fixed by also breaking on SKIP.

Fix 4 — Unconditional JSON.stringify on every RPC call (rpcLoggingProvider.ts)
Removed the JSON.stringify(params) from the debug-level request log (the raw params object is still available in structured logging). Guarded the silly-level response JSON.stringify behind a level check so it only runs when silly logging is actually enabled.