### PR TITLE
perf(rpc): format tx receipt once, not every poll

### DIFF
--- a/src/rpcLoggingProvider.ts
+++ b/src/rpcLoggingProvider.ts
@@ -6,6 +6,12 @@ import { IBridgehub__factory } from "zksync-ethers/build/typechain";
 import type { Networkish, Provider as EthersProvider, TransactionReceipt, JsonRpcApiProviderOptions } from "ethers";
 import type { Fee, TransactionRequest } from "zksync-ethers/build/types";
 
+const npmLevels = winston.config.npm.levels;
+/** Whether the default winston logger would actually emit at `level`. */
+const levelEnabled = (level: string): boolean => npmLevels[level] <= npmLevels[winston.level ?? "info"];
+
+const bigintReplacer = (_: string, value: unknown): unknown => (typeof value === "bigint" ? value.toString() : value);
+
 /** Optional auth token getter for Prividium (Authorization: Bearer). */
 export type AuthTokenGetter = () => string | null;
 
@@ -95,13 +101,13 @@ const LoggingProviderMixing = <TBase extends Ctor<EthersJsonRpcProvider>>(Base: 
       const id = this.requestId++;
       const self = this as typeof this & { getAuthToken?: AuthTokenGetter };
 
-      winston.debug(`[JSON-RPC Request] ID: ${id} Method: ${method}`, {
-        rpcRequest: {
-          id,
-          method,
-          params: JSON.stringify(params, (_, value) => (typeof value === "bigint" ? value.toString() : value)),
-        },
-      });
+      // Guard the JSON.stringify: it runs on every RPC call and is otherwise
+      // discarded by the level filter (prod runs at "info").
+      if (levelEnabled("debug")) {
+        winston.debug(`[JSON-RPC Request] ID: ${id} Method: ${method}`, {
+          rpcRequest: { id, method, params: JSON.stringify(params, bigintReplacer) },
+        });
+      }
 
       const startTime = Date.now();
       try {
@@ -123,14 +129,13 @@ const LoggingProviderMixing = <TBase extends Ctor<EthersJsonRpcProvider>>(Base: 
             method,
           },
         });
-        // Log the full response result at a lower level to avoid cluttering logs, but still have it available for debugging when needed
-        winston.silly(`[JSON-RPC Response Result] ID: ${id} Method: ${method}`, {
-          rpcResponse: {
-            id,
-            method,
-            result: JSON.stringify(result, (_, value) => (typeof value === "bigint" ? value.toString() : value)),
-          },
-        });
+        // Log the full response result at a lower level to avoid cluttering logs, but still have it available for debugging when needed.
+        // Stringifying every response is expensive (large RPC results), so only do it when silly logging is actually enabled.
+        if (levelEnabled("silly")) {
+          winston.silly(`[JSON-RPC Response Result] ID: ${id} Method: ${method}`, {
+            rpcResponse: { id, method, result: JSON.stringify(result, bigintReplacer) },
+          });
+        }
 
         return result;
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -161,39 +166,33 @@ const LoggingProviderMixing = <TBase extends Ctor<EthersJsonRpcProvider>>(Base: 
         return this.getTransactionReceipt(hash);
       }
 
-      return new Promise((resolve, reject) => {
-        let timer: null | NodeJS.Timeout = null;
+      const deadline = timeout != null ? Date.now() + timeout : null;
+      const pollMs = this.pollingInterval;
 
-        const listener = async (receipt: TransactionReceipt) => {
-          await this.once(hash, listener);
-          try {
-            if ((await receipt.confirmations()) >= confirms) {
-              resolve(receipt);
-              await this.off(hash, listener);
-              if (timer) {
-                clearTimeout(timer);
-                timer = null;
-              }
-              return;
+      for (;;) {
+        try {
+          // Cheap inclusion probe: the raw JSON-RPC result is not parsed into ethers
+          // objects, so no per-log address checksumming (keccak256) happens while
+          // polling. The receipt is only formatted once, after it is confirmed.
+          const raw = (await this.send("eth_getTransactionReceipt", [hash])) as { blockNumber?: string } | null;
+          if (raw?.blockNumber != null) {
+            if (confirms <= 1) {
+              return this.getTransactionReceipt(hash);
             }
-          } catch (error) {
-            winston.error("Error in waitForTransaction", error);
+            const current = await this.getBlockNumber();
+            if (current - Number(raw.blockNumber) + 1 >= confirms) {
+              return this.getTransactionReceipt(hash);
+            }
           }
-        };
-
-        if (timeout != null) {
-          timer = setTimeout(() => {
-            if (timer == null) {
-              return;
-            }
-            timer = null;
-            this.off(hash, listener);
-            reject(new Error("timeout"));
-          }, timeout);
+        } catch (error) {
+          winston.error("Error in waitForTransaction", error);
         }
 
-        this.once(hash, listener);
-      });
+        if (deadline != null && Date.now() >= deadline) {
+          throw new Error("timeout");
+        }
+        await new Promise((resolve) => setTimeout(resolve, pollMs));
+      }
     }
   };
 };

--- a/src/rpcLoggingProvider.ts
+++ b/src/rpcLoggingProvider.ts
@@ -166,32 +166,69 @@ const LoggingProviderMixing = <TBase extends Ctor<EthersJsonRpcProvider>>(Base: 
         return this.getTransactionReceipt(hash);
       }
 
-      const deadline = timeout != null ? Date.now() + timeout : null;
-      const pollMs = this.pollingInterval;
-
-      for (;;) {
-        try {
-          // Cheap inclusion probe: the raw JSON-RPC result is not parsed into ethers
-          // objects, so no per-log address checksumming (keccak256) happens while
-          // polling. The receipt is only formatted once, after it is confirmed.
-          const raw = (await this.send("eth_getTransactionReceipt", [hash])) as { blockNumber?: string } | null;
-          if (raw?.blockNumber != null) {
-            if (confirms <= 1) {
-              return this.getTransactionReceipt(hash);
-            }
-            const current = await this.getBlockNumber();
-            if (current - Number(raw.blockNumber) + 1 >= confirms) {
-              return this.getTransactionReceipt(hash);
-            }
-          }
-        } catch (error) {
-          winston.error("Error in waitForTransaction", error);
-        }
-
-        if (deadline != null && Date.now() >= deadline) {
+      let timer: null | NodeJS.Timeout = null;
+      let timedOut = false;
+      const failIfTimedOut = () => {
+        if (timedOut) {
           throw new Error("timeout");
         }
-        await new Promise((resolve) => setTimeout(resolve, pollMs));
+      };
+
+      const pollLoop = async (): Promise<null | TransactionReceipt> => {
+        const pollMs = this.pollingInterval;
+
+        for (;;) {
+          failIfTimedOut();
+          try {
+            // Cheap inclusion probe: the raw JSON-RPC result is not parsed into ethers
+            // objects, so no per-log address checksumming (keccak256) happens while
+            // polling. The receipt is only formatted once, after it is confirmed.
+            const raw = (await this.send("eth_getTransactionReceipt", [hash])) as { blockNumber?: string } | null;
+            failIfTimedOut();
+
+            if (raw?.blockNumber != null) {
+              if (confirms <= 1) {
+                const receipt = await this.getTransactionReceipt(hash);
+                failIfTimedOut();
+                return receipt;
+              }
+              const current = await this.getBlockNumber();
+              failIfTimedOut();
+              if (current - Number(raw.blockNumber) + 1 >= confirms) {
+                const receipt = await this.getTransactionReceipt(hash);
+                failIfTimedOut();
+                return receipt;
+              }
+            }
+          } catch (error) {
+            if (timedOut) {
+              throw error;
+            }
+            winston.error("Error in waitForTransaction", error);
+          }
+
+          await new Promise((resolve) => setTimeout(resolve, pollMs));
+        }
+      };
+
+      if (timeout == null) {
+        return pollLoop();
+      }
+
+      const timeoutPromise = new Promise<never>((_, reject) => {
+        timer = setTimeout(() => {
+          timedOut = true;
+          reject(new Error("timeout"));
+        }, timeout);
+      });
+
+      try {
+        return await Promise.race([pollLoop(), timeoutPromise]);
+      } finally {
+        timedOut = true;
+        if (timer) {
+          clearTimeout(timer);
+        }
       }
     }
   };


### PR DESCRIPTION
Fixes the era-watchdog CPU peg + memory creep -> OOM on mainnet2.

A live CPU profile of the wedged pod showed the main thread pegged in ethers receipt formatting: `getTransactionReceipt -> formatReceiptLog -> getAddress -> keccak256` (~31% keccak, ~23% `defineProperties`). `waitForTransaction` used an ethers event subscription whose re-arm loop re-fetched and re-formatted the full receipt every 100ms poll, EIP-55 keccak-checksumming every log address - yet no flow reads `receipt.logs` (only gasUsed/gasPrice/status/hash). RSS hit the 612Mi limit while the JS heap was only ~250MB, i.e. native churn from that hot loop, not a JS retention leak.

- `waitForTransaction`: poll the raw `eth_getTransactionReceipt` result (unparsed, no keccak) for inclusion, format the receipt only once after it's confirmed. Same 100ms cadence, so tx-latency measurement is unchanged.
- Guard the per-call `JSON.stringify` of RPC params/results behind a winston level check - at the prod `info` level those debug/silly logs are dropped, so the stringify was pure wasted CPU + transient allocations on every request/response.

Follow-ups (not in this PR): build a logless `TransactionReceipt` to drop keccac entirely, and optionally swap @noble keccak for `hash-wasm`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
